### PR TITLE
Limit the ammount of IBs that result from the ES query

### DIFF
--- a/es-queries/list-available-ib-results.json
+++ b/es-queries/list-available-ib-results.json
@@ -2,8 +2,12 @@
   "aggs":{
     "IBs":{
       "terms":{"field": "release",
-               "size" : 200
-              }
+               "size" : 100,
+               "order" : { "times" : "desc" }
+              },
+      "aggs":{
+               "times" : { "avg" : { "field" : "start_time" } }
+             }
           }
          },
   "size": 0


### PR DESCRIPTION
Otherwise as the index in ES gets more results, there are more json files generated for IBs exceptions and relvals incomplete results unnecessarily. 