### PR TITLE
Add link to list of PRs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -90,6 +90,7 @@
           <li><a href='managing-properties.html'>Managing users and categories</a></li>
           <li><a href='categories.html'>List categories and packages</a></li>
           <li><a href='latestIBs.html'>Latest available IBs</a></li>
+          <li><a href='/stats/pending-prs.html'>List of pending PRs</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Thanks to Ricardas we now have a per category list of PRs, sorted by their "lag" to be approved. This adds a link to it.