### PR TITLE
Improve use of singularity documentation

### DIFF
--- a/singularity.md
+++ b/singularity.md
@@ -1,19 +1,39 @@
-# Setting up SLC6 CMS environment on CentOS7
-In order to develop CMSSW for `SLC6`, one can use `singularity` to get `SLC6 CMS` environment. `singularity` is available on `lxplus7` and can be used by any user.
-Here is how you can run `singularity` to setup `cms` environment.
-```
-#login to CentOS7 system with singularity installed e.g. lxplus7 or 
+# Using singularity to develop CMSSW on other operating systems
+
+## Setting up SLC5 or SLC6 CMS environment on CentOS7
+
+In order to develop CMSSW on `SLC5` or `SLC6`, one can use [singularity](https://www.sylabs.io/docs/) to get the corresponding `SLC5/6 CMS` environment. `singularity` is available on `lxplus6` and `lxplus7`, and can be used by any user.
+Here is how you can run `singularity` to set up `CMS` environment.
+
+For `SLC6`:
+
+```shell
+# log in to CentOS7 system with singularity installed e.g. lxplus7
 ssh lxplus7
+export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"
 singularity shell -B /afs -B /eos -B /cvmfs docker://cmssw/slc6:latest
 export SCRAM_ARCH=slc6_amd64_gcc700
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 ```
 
-# Setting up CentOS7 CMS environment on SLC6
+For `SLC5`:
+
+```shell
+# log in to CentOS7 system with singularity installed e.g. lxplus7
+ssh lxplus7
+export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"
+singularity shell -B /afs -B /eos -B /cvmfs docker://clelange/slc5-cms:latest
+export SCRAM_ARCH=slc5_amd64_gcc434
+source /cvmfs/cms.cern.ch/cmsset_default.sh
 ```
-#login to SLC6 system with singularity installed e.g. lxplus6 or cmsdevXX
+
+## Setting up CentOS7 CMS environment on SLC6
+
+```shell
+# log in to SLC6 system with singularity installed e.g. lxplus6 or cmsdevXX
 ssh cmsdev15
-singularity shell -B /afs -B /cvmfs docker://cmssw/cc7:latest
+export SINGULARITY_CACHEDIR="/tmp/$(whoami)/singularity"
+singularity shell -B /afs -B /eos -B /cvmfs docker://cmssw/cc7:latest
 export SCRAM_ARCH=slc7_amd64_gcc700
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 ```


### PR DESCRIPTION
- Add SINGULARITY_CACHEDIR to avoid filling up user home
- link to singularity documentation
- add SLC5 example (using mine for now)
- mount afs, eos, and cvmfs in all cases
- format using prettier

I would also suggest to link this file from either the main documentation page or the general CMSSW development page.