### PR TITLE
 add -A in git cms-checkdeps instructions in  PRWorkflow

### DIFF
--- a/PRWorkflow.md
+++ b/PRWorkflow.md
@@ -23,7 +23,7 @@ Confirm that you have checked out all dependencies, have a clean build, and all 
 ```
 cd src
 scram b distclean 
-git cms-checkdeps -a
+git cms-checkdeps -a -A
 scram b -j 8
 scram b runtests
 ```


### PR DESCRIPTION
There were some reports already that the dependency check is sometimes incomplete.
This adds -A for a more complete check in  PRWorkflow

~Thanks for suggesting changes but please create a Pull Request for **code** branch.~ DONE
