### PR TITLE
restore typo fixes

### DIFF
--- a/cms-bot-cmssw-cmds.md
+++ b/cms-bot-cmssw-cmds.md
@@ -13,11 +13,11 @@ For CMSSW **Pull requests**, following commands in first line of a comment are r
   - **```type [new-]feature|[new-]idea```**: To add `new-feature` lebal
   - **```type doc[umentation]|performance|improvements|performance-improvements```**: To add `documentation` and/or `performance-improvements` label
 - **```code-checks[ with cms.weekN.PR_hash/tool-conf-version]```**: By default cms-bot runs code-checks for all Pull Requests made for master branch. If for any reason code-checks tests are not run then one can force start code-checks using this command. In case an external update is needed to run code-checks (e.g. due to interface changes in header files) then first run PR tests for cmsdist/external which should deploy externals on CVMFS. Then request the code-checks with the newly deployed externals tools configuration e.g. `code-checks with cms.week0_PR_01234567/47.0-cms2` (external tools configuration is available via cmsdist PR summary page)
-- **Ignoring PR tests results**: Any one who can trigger tests can issue this command or use test parameters to ignore some of the PR tests results e.g.
+- **Ignoring PR tests results**: Anyone who can trigger tests can issue this command or use test parameters to ignore some of the PR tests results e.g.
   - **```ignore clang-warnings```**: To ignore clang warnings results
   - **```ignore build-warnings```**: To ignore build warnings results
   - **```ignore none```**: Do not ignore any tests results.
-- **Enable extra PR tests**: Any one who can trigger tests can issue this command or use test parameters to enable some exra PR tests e.g.
+- **Enable extra PR tests**: Anyone who can trigger tests can issue this command or use test parameters to enable some extra PR tests e.g.
   - **```enable gpu,threading,profiling,high_stats```**: To run extra GPU, threading relval and profiling tests
   - **```enable profiling```**: To run Igprof and generate resource graphs
   - **```enable high_stats```**: To run high stats relvals tests


### PR DESCRIPTION
The merge in dc1e2cbffd790b926512fe383ba930831f590de8 accidentally reverted some of the typo fixes in #102. The fixes are restored here.